### PR TITLE
fix: adapt IntelligenceService to yfinance API changes

### DIFF
--- a/src/options_arena/services/intelligence.py
+++ b/src/options_arena/services/intelligence.py
@@ -96,14 +96,12 @@ class IntelligenceService:
                 )
 
             # Both empty → nothing to report
-            targets_empty = targets_df is None or (
-                hasattr(targets_df, "empty") and targets_df.empty
-            )
+            targets_empty = targets_df is None or not targets_df
             recs_empty = recs_df is None or (hasattr(recs_df, "empty") and recs_df.empty)
             if targets_empty and recs_empty:
                 return None
 
-            # Parse targets
+            # Parse targets — yfinance returns a dict, not a DataFrame
             target_low: float | None = None
             target_high: float | None = None
             target_mean: float | None = None
@@ -111,13 +109,11 @@ class IntelligenceService:
             target_current: float | None = None
 
             if not targets_empty:
-                row = targets_df.iloc[0] if len(targets_df) > 0 else None
-                if row is not None:
-                    target_low = safe_float(row.get("low"))
-                    target_high = safe_float(row.get("high"))
-                    target_mean = safe_float(row.get("mean"))
-                    target_median = safe_float(row.get("median"))
-                    target_current = safe_float(row.get("current"))
+                target_low = safe_float(targets_df.get("low"))
+                target_high = safe_float(targets_df.get("high"))
+                target_mean = safe_float(targets_df.get("mean"))
+                target_median = safe_float(targets_df.get("median"))
+                target_current = safe_float(targets_df.get("current"))
 
             # Parse recommendations — filter to period == "0m"
             strong_buy = 0
@@ -495,7 +491,7 @@ class IntelligenceService:
             async with self._limiter:
                 ticker_obj = yf.Ticker(ticker)
                 news_items = await asyncio.wait_for(
-                    asyncio.to_thread(ticker_obj.get_news, _count=10),
+                    asyncio.to_thread(ticker_obj.get_news, count=10),
                     timeout=self._config.request_timeout,
                 )
 

--- a/tests/unit/services/test_intelligence_service.py
+++ b/tests/unit/services/test_intelligence_service.py
@@ -113,17 +113,15 @@ def _make_service(
 # ---------------------------------------------------------------------------
 
 
-def _make_analyst_targets_df() -> pd.DataFrame:
-    """Build a yfinance-style analyst price targets DataFrame."""
-    return pd.DataFrame(
-        {
-            "current": [185.0],
-            "low": [150.0],
-            "high": [220.0],
-            "mean": [195.0],
-            "median": [192.0],
-        }
-    )
+def _make_analyst_targets_dict() -> dict[str, float]:
+    """Build a yfinance-style analyst price targets dict."""
+    return {
+        "current": 185.0,
+        "low": 150.0,
+        "high": 220.0,
+        "mean": 195.0,
+        "median": 192.0,
+    }
 
 
 def _make_recommendations_df() -> pd.DataFrame:
@@ -258,7 +256,7 @@ class TestFetchAnalystTargets:
     ) -> None:
         """Happy path should return a fully populated AnalystSnapshot."""
         service = _make_service(config, mock_cache, mock_limiter)
-        targets_df = _make_analyst_targets_df()
+        targets_df = _make_analyst_targets_dict()
         recs_df = _make_recommendations_df()
 
         mock_ticker = MagicMock()
@@ -382,11 +380,11 @@ class TestFetchAnalystTargets:
     async def test_empty_dataframe_returns_none(
         self, config: IntelligenceConfig, mock_cache: MagicMock, mock_limiter: MagicMock
     ) -> None:
-        """Should return None when both DataFrames are empty."""
+        """Should return None when targets dict is empty and recs DataFrame is empty."""
         service = _make_service(config, mock_cache, mock_limiter)
 
         mock_ticker = MagicMock()
-        mock_ticker.get_analyst_price_targets = MagicMock(return_value=pd.DataFrame())
+        mock_ticker.get_analyst_price_targets = MagicMock(return_value={})
         mock_ticker.get_recommendations = MagicMock(return_value=pd.DataFrame())
 
         with patch("options_arena.services.intelligence.yf.Ticker", return_value=mock_ticker):
@@ -403,7 +401,7 @@ class TestFetchAnalystTargets:
         Formula: (5*2 + 10*1 + 8*0 + 2*-1 + 1*-2) / (26*2) = 16/52 = 0.3077
         """
         service = _make_service(config, mock_cache, mock_limiter)
-        targets_df = _make_analyst_targets_df()
+        targets_df = _make_analyst_targets_dict()
         recs_df = _make_recommendations_df()
 
         mock_ticker = MagicMock()
@@ -428,7 +426,7 @@ class TestFetchAnalystTargets:
         (195.0 - 185.0) / 185.0 = 0.054054...
         """
         service = _make_service(config, mock_cache, mock_limiter)
-        targets_df = _make_analyst_targets_df()
+        targets_df = _make_analyst_targets_dict()
         recs_df = _make_recommendations_df()
 
         mock_ticker = MagicMock()
@@ -448,7 +446,7 @@ class TestFetchAnalystTargets:
     ) -> None:
         """Should cache result on successful fetch."""
         service = _make_service(config, mock_cache, mock_limiter)
-        targets_df = _make_analyst_targets_df()
+        targets_df = _make_analyst_targets_dict()
         recs_df = _make_recommendations_df()
 
         mock_ticker = MagicMock()
@@ -1069,7 +1067,7 @@ class TestFetchIntelligence:
         """Should return IntelligencePackage with all fields populated."""
         service = _make_service(config, mock_cache, mock_limiter)
 
-        targets_df = _make_analyst_targets_df()
+        targets_df = _make_analyst_targets_dict()
         recs_df = _make_recommendations_df()
         ud_df = _make_upgrades_downgrades_df()
         insider_df = _make_insider_transactions_df()
@@ -1106,7 +1104,7 @@ class TestFetchIntelligence:
         """Should return partial IntelligencePackage when some methods fail."""
         service = _make_service(config, mock_cache, mock_limiter)
 
-        targets_df = _make_analyst_targets_df()
+        targets_df = _make_analyst_targets_dict()
         recs_df = _make_recommendations_df()
         news_data = _make_news_response()
 


### PR DESCRIPTION
## Summary

- **fetch_analyst_targets**: `yfinance.Ticker.get_analyst_price_targets()` now returns a `dict` instead of a `DataFrame`. Replaced `.iloc[0]` / `row.get()` with direct `dict.get()` calls, and fixed the empty-check (dict has no `.empty` attribute).
- **fetch_news_headlines**: Fixed `get_news()` parameter from `_count=10` to `count=10` (correct yfinance signature).
- Updated test helper `_make_analyst_targets_df()` → `_make_analyst_targets_dict()` to match the new return type, plus all 7 call sites.

Both bugs were caught by the never-raises contract (logged as WARNING, returned None), so debates still completed — but analyst targets and news headlines were silently lost.

## Test plan

- [x] `uv run ruff check . --fix && uv run ruff format .` — all checks passed
- [x] `uv run pytest tests/unit/services/test_intelligence_service.py -v` — 45/45 passed
- [x] `uv run pytest tests/ -x -q` — 3,840 passed
- [x] `uv run mypy src/options_arena/services/intelligence.py --strict` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of empty analyst targets data
  * Fixed parameter alignment in news headline fetching routine

* **Refactor**
  * Updated analyst targets data parsing to align with data source format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->