### PR TITLE
fix: prevent heatmap flicker and disappearance on dashboard

### DIFF
--- a/web/src/components/MarketHeatmap.vue
+++ b/web/src/components/MarketHeatmap.vue
@@ -29,7 +29,7 @@ watch(containerRef, (el) => {
     })
     resizeObserver.observe(el)
   }
-})
+}, { flush: 'post' })
 
 // ---------------------------------------------------------------------------
 // Squarify algorithm (standard Bruls-Huizing-van Wijk 2000)
@@ -374,8 +374,8 @@ onUnmounted(() => {
       />
     </div>
 
-    <!-- Loading -->
-    <div v-if="store.loading && store.tickers.length === 0" class="heatmap-skeleton">
+    <!-- Loading (show skeleton until the first fetch completes) -->
+    <div v-if="!store.initialized || (store.loading && store.tickers.length === 0)" class="heatmap-skeleton">
       <Skeleton width="100%" height="500px" />
     </div>
 

--- a/web/src/stores/heatmap.ts
+++ b/web/src/stores/heatmap.ts
@@ -9,18 +9,27 @@ export const useHeatmapStore = defineStore('heatmap', () => {
   const loading = ref(false)
   const error = ref<string | null>(null)
   const lastUpdated = ref<Date | null>(null)
+  /** True after the first fetch attempt completes (success or error). */
+  const initialized = ref(false)
 
   // --- Actions ---
   async function fetchHeatmap(): Promise<void> {
     loading.value = true
     error.value = null
     try {
-      tickers.value = await api<HeatmapTicker[]>('/api/market/heatmap')
+      const result = await api<HeatmapTicker[]>('/api/market/heatmap')
+      // Preserve stale data when the API returns empty but we already have
+      // good data — prevents the treemap from disappearing on transient
+      // failures (timeouts, partial yfinance outages, etc.).
+      if (result.length > 0 || tickers.value.length === 0) {
+        tickers.value = result
+      }
       lastUpdated.value = new Date()
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to fetch heatmap'
     } finally {
       loading.value = false
+      initialized.value = true
     }
   }
 
@@ -43,6 +52,7 @@ export const useHeatmapStore = defineStore('heatmap', () => {
     loading,
     error,
     lastUpdated,
+    initialized,
     fetchHeatmap,
     startAutoRefresh,
     stopAutoRefresh,


### PR DESCRIPTION
## Summary
- Preserve stale heatmap data when API refetch returns empty (timeout/outage)
- Add `initialized` flag to show skeleton until first fetch completes (prevents flash of "No data")
- Fix `containerRef` watch flush timing for reliable DOM measurement

## Test plan
- [x] 19/19 heatmap route tests pass
- [x] TypeScript check clean (`vue-tsc --noEmit`)
- [x] Frontend builds successfully
- [ ] Manual: verify heatmap renders on dashboard without flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved loading indicator visibility during initial heatmap data fetch
  * Market data is now preserved when a refresh encounters empty results, maintaining data continuity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->