### PR TITLE
fix: reduce OHLCV cache TTL during market hours

### DIFF
--- a/src/options_arena/services/cache.py
+++ b/src/options_arena/services/cache.py
@@ -24,7 +24,8 @@ logger = logging.getLogger(__name__)
 # Named TTL constants (seconds) — never use magic numbers
 # ---------------------------------------------------------------------------
 
-TTL_OHLCV: int = 6 * 60 * 60  # 6 hrs — daily bars refresh between scan runs
+TTL_OHLCV_MARKET: int = 30 * 60  # 30 min — capture intraday movement between scans
+TTL_OHLCV_AFTER: int = 6 * 60 * 60  # 6 hrs — daily bars stable after close
 TTL_CHAIN_MARKET: int = 5 * 60  # 5 min during market hours
 TTL_CHAIN_AFTER: int = 60 * 60  # 1 hr after hours
 TTL_QUOTE_MARKET: int = 1 * 60  # 1 min during market hours
@@ -269,7 +270,7 @@ class ServiceCache:
 
         match data_type:
             case "ohlcv":
-                return TTL_OHLCV
+                return TTL_OHLCV_MARKET if market_open else TTL_OHLCV_AFTER
             case "chain":
                 return TTL_CHAIN_MARKET if market_open else TTL_CHAIN_AFTER
             case "quote":

--- a/src/options_arena/services/market_data.py
+++ b/src/options_arena/services/market_data.py
@@ -31,7 +31,6 @@ from options_arena.services.base import ServiceBase
 from options_arena.services.cache import (
     TTL_EARNINGS,
     TTL_FUNDAMENTALS,
-    TTL_OHLCV,
     TTL_REFERENCE,
     ServiceCache,
 )
@@ -384,7 +383,7 @@ class MarketDataService(ServiceBase[ServiceConfig]):
 
         # Cache result
         serialized = _serialize_ohlcv_list(records)
-        await self._cache.set(cache_key, serialized, ttl=TTL_OHLCV)
+        await self._cache.set(cache_key, serialized, ttl=self._cache.ttl_for("ohlcv"))
 
         self._log.debug("Fetched %d OHLCV bars for %s (period=%s)", len(records), ticker, period)
         return records

--- a/tests/unit/services/test_cache.py
+++ b/tests/unit/services/test_cache.py
@@ -14,7 +14,8 @@ from options_arena.services.cache import (
     TTL_CHAIN_MARKET,
     TTL_FAILURE,
     TTL_FUNDAMENTALS,
-    TTL_OHLCV,
+    TTL_OHLCV_AFTER,
+    TTL_OHLCV_MARKET,
     TTL_QUOTE_AFTER,
     TTL_QUOTE_MARKET,
     TTL_REFERENCE,
@@ -145,6 +146,18 @@ async def test_lru_evicts_oldest_entry(config: ServiceConfig) -> None:
 # ---------------------------------------------------------------------------
 
 
+async def test_ttl_for_ohlcv_market_hours(memory_cache: ServiceCache) -> None:
+    """During market hours, OHLCV TTL uses the shorter 30-min value."""
+    with patch("options_arena.services.cache.is_market_hours", return_value=True):
+        assert memory_cache.ttl_for("ohlcv") == TTL_OHLCV_MARKET
+
+
+async def test_ttl_for_ohlcv_after_hours(memory_cache: ServiceCache) -> None:
+    """After hours, OHLCV TTL uses the longer 6-hour value."""
+    with patch("options_arena.services.cache.is_market_hours", return_value=False):
+        assert memory_cache.ttl_for("ohlcv") == TTL_OHLCV_AFTER
+
+
 async def test_ttl_for_chain_market_hours(memory_cache: ServiceCache) -> None:
     """During market hours, chain TTL uses the shorter market-hours value."""
     with patch("options_arena.services.cache.is_market_hours", return_value=True):
@@ -160,7 +173,7 @@ async def test_ttl_for_chain_after_hours(memory_cache: ServiceCache) -> None:
 async def test_ttl_for_all_data_types(memory_cache: ServiceCache) -> None:
     """Verify correct TTL for each known data type during market hours."""
     with patch("options_arena.services.cache.is_market_hours", return_value=True):
-        assert memory_cache.ttl_for("ohlcv") == TTL_OHLCV
+        assert memory_cache.ttl_for("ohlcv") == TTL_OHLCV_MARKET
         assert memory_cache.ttl_for("chain") == TTL_CHAIN_MARKET
         assert memory_cache.ttl_for("quote") == TTL_QUOTE_MARKET
         assert memory_cache.ttl_for("fundamentals") == TTL_FUNDAMENTALS
@@ -360,7 +373,8 @@ async def test_get_nonexistent_returns_none(memory_cache: ServiceCache) -> None:
 
 def test_ttl_constants_values() -> None:
     """Verify named TTL constants have the expected values in seconds."""
-    assert TTL_OHLCV == 6 * 60 * 60
+    assert TTL_OHLCV_MARKET == 30 * 60
+    assert TTL_OHLCV_AFTER == 6 * 60 * 60
     assert TTL_CHAIN_MARKET == 300
     assert TTL_CHAIN_AFTER == 3600
     assert TTL_QUOTE_MARKET == 60


### PR DESCRIPTION
## Summary
- Split `TTL_OHLCV` (6h) into `TTL_OHLCV_MARKET` (30 min) and `TTL_OHLCV_AFTER` (6h)
- OHLCV caching is now market-hours-aware, matching the existing pattern for chains and quotes
- Scans run >30 min apart during market hours will now pick up intraday price changes

## Test plan
- [x] All 28 cache tests pass (including 2 new OHLCV market-hours tests)
- [x] All 65 market_data tests pass
- [ ] Manual: run two scans 30+ min apart during market hours — verify different top-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OHLCV data cache duration now adapts based on market status: 30 minutes during market hours, 6 hours outside market hours.

* **Tests**
  * Updated tests to verify market-aware caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->