### PR TITLE
fix: populate agent prediction contract linkage

### DIFF
--- a/data/migrations/030_backfill_prediction_contracts.sql
+++ b/data/migrations/030_backfill_prediction_contracts.sql
@@ -1,0 +1,13 @@
+-- Backfill agent_predictions.recommended_contract_id from ai_theses + recommended_contracts.
+-- Links each prediction to its contract via the debate's scan_run_id and ticker.
+UPDATE agent_predictions
+SET recommended_contract_id = (
+    SELECT rc.id
+    FROM ai_theses at_
+    JOIN recommended_contracts rc
+      ON rc.scan_run_id = at_.scan_run_id AND rc.ticker = at_.ticker
+    WHERE at_.id = agent_predictions.debate_id
+    ORDER BY rc.id DESC
+    LIMIT 1
+)
+WHERE recommended_contract_id IS NULL;

--- a/src/options_arena/agents/orchestrator.py
+++ b/src/options_arena/agents/orchestrator.py
@@ -728,6 +728,7 @@ def _opposite_direction(direction: SignalDirection) -> SignalDirection:
 def extract_agent_predictions(
     debate_id: int,
     result: DebateResult,
+    recommended_contract_id: int | None = None,
 ) -> list[AgentPrediction]:
     """Extract per-agent predictions from a DebateResult for accuracy tracking.
 
@@ -739,6 +740,12 @@ def extract_agent_predictions(
     Extract as "trend" to avoid conflating with the retired bull agent.
     ``bear_response`` is a static fallback — skip it to avoid misleading data.
 
+    Args:
+        debate_id: Database ID of the persisted debate.
+        result: Completed debate result with agent responses.
+        recommended_contract_id: Matching contract from ``recommended_contracts``
+            table.  Needed for accuracy queries that JOIN predictions to outcomes.
+
     Returns a list of ``AgentPrediction`` — empty if all agents failed.
     """
     now = datetime.now(UTC)
@@ -749,6 +756,7 @@ def extract_agent_predictions(
         predictions.append(
             AgentPrediction(
                 debate_id=debate_id,
+                recommended_contract_id=recommended_contract_id,
                 agent_name="trend",
                 direction=result.bull_response.direction,
                 confidence=result.bull_response.confidence,
@@ -761,6 +769,7 @@ def extract_agent_predictions(
         predictions.append(
             AgentPrediction(
                 debate_id=debate_id,
+                recommended_contract_id=recommended_contract_id,
                 agent_name="flow",
                 direction=result.flow_response.direction,
                 confidence=result.flow_response.confidence,
@@ -773,6 +782,7 @@ def extract_agent_predictions(
         predictions.append(
             AgentPrediction(
                 debate_id=debate_id,
+                recommended_contract_id=recommended_contract_id,
                 agent_name="fundamental",
                 direction=result.fundamental_response.direction,
                 confidence=result.fundamental_response.confidence,
@@ -785,6 +795,7 @@ def extract_agent_predictions(
         predictions.append(
             AgentPrediction(
                 debate_id=debate_id,
+                recommended_contract_id=recommended_contract_id,
                 agent_name="volatility",
                 direction=result.vol_response.direction,
                 confidence=result.vol_response.confidence,
@@ -797,6 +808,7 @@ def extract_agent_predictions(
         predictions.append(
             AgentPrediction(
                 debate_id=debate_id,
+                recommended_contract_id=recommended_contract_id,
                 agent_name="risk",
                 direction=None,
                 confidence=result.risk_response.confidence,
@@ -809,6 +821,7 @@ def extract_agent_predictions(
         predictions.append(
             AgentPrediction(
                 debate_id=debate_id,
+                recommended_contract_id=recommended_contract_id,
                 agent_name="contrarian",
                 direction=result.contrarian_response.dissent_direction,
                 confidence=result.contrarian_response.dissent_confidence,
@@ -872,8 +885,15 @@ async def _persist_result(
             contrarian_thesis=result.contrarian_response,
         )
 
+        # Look up the recommended contract for this debate's scan+ticker pair.
+        # This links agent predictions to contract outcomes for accuracy tracking.
+        contract_id = await repository.get_recommended_contract_id(
+            ticker_score.scan_run_id,
+            result.context.ticker,
+        )
+
         # Persist per-agent predictions for accuracy tracking (FR-8)
-        predictions = extract_agent_predictions(debate_id, result)
+        predictions = extract_agent_predictions(debate_id, result, contract_id)
         if predictions:
             await repository.save_agent_predictions(predictions)
 

--- a/src/options_arena/data/_debate.py
+++ b/src/options_arena/data/_debate.py
@@ -141,12 +141,13 @@ class DebateMixin(RepositoryBase):
         conn = self._db.conn
         await conn.executemany(
             "INSERT OR IGNORE INTO agent_predictions "
-            "(debate_id, agent_name, direction, confidence, created_at) "
-            "VALUES (?, ?, ?, ?, ?)",
+            "(debate_id, agent_name, recommended_contract_id, direction, confidence, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
             [
                 (
                     p.debate_id,
                     p.agent_name,
+                    p.recommended_contract_id,
                     p.direction.value if p.direction is not None else None,
                     p.confidence,
                     p.created_at.isoformat(),
@@ -160,6 +161,30 @@ class DebateMixin(RepositoryBase):
             len(predictions),
             predictions[0].debate_id,
         )
+
+    async def get_recommended_contract_id(
+        self,
+        scan_run_id: int | None,
+        ticker: str,
+    ) -> int | None:
+        """Look up the recommended_contracts.id for a scan_run + ticker pair.
+
+        Returns the most recently inserted contract ID, or ``None`` if no match
+        (e.g. standalone debates without a prior scan run).
+        """
+        if scan_run_id is None:
+            return None
+        conn = self._db.conn
+        async with conn.execute(
+            "SELECT id FROM recommended_contracts "
+            "WHERE scan_run_id = ? AND ticker = ? "
+            "ORDER BY id DESC LIMIT 1",
+            (scan_run_id, ticker),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None:
+            return None
+        return int(row[0])
 
     async def get_debate_by_id(self, debate_id: int) -> DebateRow | None:
         """Get a single debate by its primary key, or None if not found."""

--- a/src/options_arena/models/analysis.py
+++ b/src/options_arena/models/analysis.py
@@ -825,6 +825,7 @@ class AgentPrediction(BaseModel):
 
     debate_id: int
     agent_name: str
+    recommended_contract_id: int | None = None
     direction: SignalDirection | None = None
     confidence: float
     created_at: datetime

--- a/tests/unit/agents/test_orchestrator_v2.py
+++ b/tests/unit/agents/test_orchestrator_v2.py
@@ -173,6 +173,8 @@ class TestPersistResult:
         """
         mock_repo = MagicMock()
         mock_repo.save_debate = AsyncMock(return_value=1)
+        mock_repo.get_recommended_contract_id = AsyncMock(return_value=42)
+        mock_repo.save_agent_predictions = AsyncMock()
 
         config = DebateConfig(
             api_key="test-key-not-used-with-TestModel",
@@ -208,6 +210,14 @@ class TestPersistResult:
         assert isinstance(call_kwargs["risk_assessment"], RiskAssessment)
         assert call_kwargs["contrarian_thesis"] is not None
         assert isinstance(call_kwargs["contrarian_thesis"], ContrarianThesis)
+
+        # Agent predictions saved with recommended_contract_id populated
+        mock_repo.get_recommended_contract_id.assert_awaited_once()
+        mock_repo.save_agent_predictions.assert_awaited_once()
+        saved_predictions = mock_repo.save_agent_predictions.call_args[0][0]
+        assert len(saved_predictions) > 0
+        for pred in saved_predictions:
+            assert pred.recommended_contract_id == 42
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/data/test_agent_predictions.py
+++ b/tests/unit/data/test_agent_predictions.py
@@ -18,7 +18,7 @@ import pytest_asyncio
 
 from options_arena.data.database import Database
 from options_arena.data.repository import Repository
-from options_arena.models import AgentPrediction, SignalDirection
+from options_arena.models import AgentPrediction, ScanPreset, ScanRun, SignalDirection
 
 pytestmark = pytest.mark.db
 
@@ -280,3 +280,111 @@ async def test_created_at_persisted_as_iso(repo: Repository, db: Database) -> No
     # Should be a valid ISO 8601 string parseable back to datetime
     parsed = datetime.fromisoformat(row["created_at"])
     assert parsed.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# recommended_contract_id linkage tests
+# ---------------------------------------------------------------------------
+
+
+async def _create_scan_and_contract(repo: Repository) -> tuple[int, int]:
+    """Insert a scan run + recommended contract, return (scan_run_id, contract_id)."""
+    scan_run = ScanRun(
+        started_at=NOW,
+        completed_at=NOW,
+        preset=ScanPreset.SP500,
+        tickers_scanned=10,
+        tickers_scored=5,
+        recommendations=1,
+    )
+    scan_id = await repo.save_scan_run(scan_run)
+    conn = repo._db.conn  # noqa: SLF001
+    cursor = await conn.execute(
+        "INSERT INTO recommended_contracts "
+        "(scan_run_id, ticker, option_type, strike, bid, ask, expiration, "
+        "volume, open_interest, market_iv, exercise_style, entry_mid, direction, "
+        "composite_score, risk_free_rate, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            scan_id,
+            "AAPL",
+            "call",
+            "190.00",
+            "3.50",
+            "3.80",
+            "2026-04-18",
+            1000,
+            5000,
+            0.30,
+            "american",
+            "3.65",
+            "bullish",
+            78.5,
+            0.045,
+            NOW.isoformat(),
+        ),
+    )
+    await conn.commit()
+    assert cursor.lastrowid is not None
+    return scan_id, cursor.lastrowid
+
+
+@pytest.mark.asyncio
+async def test_save_predictions_with_contract_id(repo: Repository, db: Database) -> None:
+    """Verify recommended_contract_id is persisted when provided."""
+    scan_id, contract_id = await _create_scan_and_contract(repo)
+    debate_id = await repo.save_debate(
+        scan_run_id=scan_id,
+        ticker="AAPL",
+        bull_json="{}",
+        bear_json="{}",
+        risk_json=None,
+        verdict_json="{}",
+        total_tokens=100,
+        model_name="test",
+        duration_ms=500,
+        is_fallback=False,
+    )
+    predictions = [
+        AgentPrediction(
+            debate_id=debate_id,
+            recommended_contract_id=contract_id,
+            agent_name="trend",
+            direction=SignalDirection.BULLISH,
+            confidence=0.75,
+            created_at=NOW,
+        ),
+    ]
+    await repo.save_agent_predictions(predictions)
+
+    conn = db.conn
+    async with conn.execute(
+        "SELECT recommended_contract_id FROM agent_predictions WHERE debate_id = ?",
+        (debate_id,),
+    ) as cursor:
+        row = await cursor.fetchone()
+
+    assert row is not None
+    assert row["recommended_contract_id"] == contract_id
+
+
+@pytest.mark.asyncio
+async def test_get_recommended_contract_id(repo: Repository) -> None:
+    """Verify helper returns the correct contract ID for a scan+ticker pair."""
+    scan_id, contract_id = await _create_scan_and_contract(repo)
+    result = await repo.get_recommended_contract_id(scan_id, "AAPL")
+    assert result == contract_id
+
+
+@pytest.mark.asyncio
+async def test_get_recommended_contract_id_no_match(repo: Repository) -> None:
+    """Verify helper returns None when no matching contract exists."""
+    result = await repo.get_recommended_contract_id(999, "ZZZZZ")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_recommended_contract_id_none_scan(repo: Repository) -> None:
+    """Verify helper returns None when scan_run_id is None (standalone debate)."""
+    result = await repo.get_recommended_contract_id(None, "AAPL")
+    assert result is None


### PR DESCRIPTION
## Summary
- **Bug**: `agent_predictions.recommended_contract_id` was never populated, causing all accuracy queries and auto-tune to return 0 rows
- **Fix**: Orchestrator now looks up contract ID via `scan_run_id + ticker` after `save_debate()` and passes it through to `save_agent_predictions()`
- **Backfill**: Migration 030 updates existing NULL rows via correlated subquery

## Changes
- `models/analysis.py`: Added `recommended_contract_id` field to `AgentPrediction`
- `agents/orchestrator.py`: Updated `extract_agent_predictions()` + `_persist_result()` to propagate contract ID
- `data/_debate.py`: Fixed INSERT to include column, added `get_recommended_contract_id()` helper
- `data/migrations/030_backfill_prediction_contracts.sql`: Backfill existing data
- Tests: 4 new persistence tests + updated orchestrator test with contract linkage assertions

## Test plan
- [x] 24,075 tests pass (`uv run pytest tests/ -n auto -q`)
- [x] Lint clean (`uv run ruff check .`)
- [x] Type check clean (`uv run mypy src/ --strict`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent predictions now include an optional link to recommended contracts.
  * Added retrieval of the most-recent recommended contract by scan run and ticker.

* **Chores**
  * Database migration to backfill recommended contract links for existing predictions.

* **Tests**
  * Added unit and integration tests to verify persistence and retrieval of the contract linkage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->